### PR TITLE
カテゴリーIDカラムの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ belongs_to:user
 |price|integer|null:false|
 |text｜text｜null:false｜
 |user_id|integer|null:false,foreign_key:true|
-|brand_id|integer|null:false,foreign_key:true|
+|brand_id|integer|foreign_key:true|
 |category_id|integer|null:false,foreign_key:true|
 ### Association
 belongs_to:user

--- a/db/migrate/20191204035911_create_items.rb
+++ b/db/migrate/20191204035911_create_items.rb
@@ -10,8 +10,9 @@ class CreateItems < ActiveRecord::Migration[5.0]
       t.integer :shipping_price, null:false
       t.integer :price, null:false
       t.text :text, null:false
-      t.integer :user_id, null:false,foreign_key:true
-      t.integer :brand_id, null:false,foreign_key:true
+      t.integer :user_id, null:false, foreign_key:true
+      t.integer :category_id, null:false, foreign_key:true
+      t.integer :brand_id, foreign_key:true
       t.timestamps
     end
   end


### PR DESCRIPTION
#what
itemテーブルにカテゴリーIDカラムの追加
itemテーブルのブランドIDカラムのnil:falseを外した

#why
カテゴリーカラムがなかったため
ノーブランドの商品もあるため